### PR TITLE
5 - Chore: Phonenumber to text migration

### DIFF
--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -12,8 +12,7 @@ This project is split across 4 different PRs, each branching off the previous on
 - Implement automated tests
 
 ### Frontend
-- Add loading states for better user experience
-- Implement error handling and states
+- Add error boundires to ensure app doesn't crash
 - Make the table responsive and mobile-friendly
 - Enhance data fetching with ReactQuery or SSR
 - Refactor the table into its own component

--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -2,7 +2,7 @@
 
 Thanks for checking out my code!
 
-This project is split across 4 different PRs, each branching off the previous one. I structured it this way to make the code easily testable and review-friendly. For running the application, I recommend using the `clean-up` branch as it contains all the changes and updates.
+This project is split across 4 different PRs, each branching off the previous one. I structured it this way to make the code easily testable and review-friendly. For running the application, I recommend using the `phone-to-text-migration` branch as it contains all the changes and updates.
 
 ## Future Improvements
 

--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -2,7 +2,7 @@
 
 Thanks for checking out my code!
 
-This project is split across 4 different PRs, each branching off the previous one. I structured it this way to make the code easily testable and review-friendly. For running the application, I recommend using the `phone-to-text-migration` branch as it contains all the changes and updates.
+This project is split across 5 different PRs, each branching off the previous one. I structured it this way to make the code easily testable and review-friendly. For running the application, I recommend using the `phone-to-text-migration` branch as it contains all the changes and updates.
 
 ## Future Improvements
 

--- a/drizzle/0000_sticky_sunfire.sql
+++ b/drizzle/0000_sticky_sunfire.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS "advocates" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"first_name" text NOT NULL,
+	"last_name" text NOT NULL,
+	"city" text NOT NULL,
+	"degree" text NOT NULL,
+	"payload" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"years_of_experience" integer NOT NULL,
+	"phone_number" text NOT NULL,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);

--- a/drizzle/0001_change_phone_to_text.sql
+++ b/drizzle/0001_change_phone_to_text.sql
@@ -1,0 +1,16 @@
+-- Migration to convert phone_number from bigint to text
+
+-- Add a new column for the text version
+ALTER TABLE "advocates" ADD COLUMN "phone_number_text" text;
+
+-- Copy and convert data from the bigint column to the text column
+UPDATE "advocates" SET "phone_number_text" = "phone_number"::text;
+
+-- Make the new column NOT NULL after data is copied
+ALTER TABLE "advocates" ALTER COLUMN "phone_number_text" SET NOT NULL;
+
+-- Drop the old bigint column
+ALTER TABLE "advocates" DROP COLUMN "phone_number";
+
+-- Rename the new text column to the original name
+ALTER TABLE "advocates" RENAME COLUMN "phone_number_text" TO "phone_number";

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,82 @@
+{
+  "id": "2b06ab13-fb98-44bf-87f0-9e46338cf2e6",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.advocates": {
+      "name": "advocates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "degree": {
+          "name": "degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "years_of_experience": {
+          "name": "years_of_experience",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,82 @@
+{
+  "id": "8ab224e5-b7e3-445d-a5b7-0987c5e06ff3",
+  "prevId": "2b06ab13-fb98-44bf-87f0-9e46338cf2e6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.advocates": {
+      "name": "advocates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "degree": {
+          "name": "degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "years_of_experience": {
+          "name": "years_of_experience",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,20 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1744499463087,
+      "tag": "0000_sticky_sunfire",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1744501932155,
+      "tag": "0001_change_phone_to_text",
+      "breakpoints": true
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "solace-candidate-assignment",
       "version": "0.1.0",
       "dependencies": {
+        "dotenv": "^16.5.0",
         "drizzle-orm": "^0.32.1",
         "next": "^14.2.19",
         "postgres": "^3.4.4",
@@ -2094,6 +2095,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/drizzle-kit": {

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
     "lint": "next lint",
     "format": "npx prettier --write",
     "generate": "drizzle-kit generate",
+    "generate:custom": "drizzle-kit generate --custom",
     "migrate:up": "node ./src/db/migrate.js",
     "seed": "node --loader esbuild-register/loader -r esbuild-register ./src/db/seed/index.ts"
   },
   "dependencies": {
+    "dotenv": "^16.5.0",
     "drizzle-orm": "^0.32.1",
     "next": "^14.2.19",
     "postgres": "^3.4.4",

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -22,7 +22,6 @@ export async function GET(request: NextRequest) {
     let conditions = undefined;
     
     if (searchTerm) {
-      // Using sql template literals for proper parameterization
       // Specialties is a jsonb array, so we need to search within it
       const specialtiesSearch = sql`EXISTS (
         SELECT 1 FROM jsonb_array_elements_text(${advocates.specialties}) as specialty
@@ -38,7 +37,7 @@ export async function GET(request: NextRequest) {
         sql`${advocates.degree} ILIKE ${'%' + searchTerm + '%'}`,
         specialtiesSearch,
         sql`CAST(${advocates.yearsOfExperience} AS TEXT) ILIKE ${'%' + searchTerm + '%'}`,
-        sql`CAST(${advocates.phoneNumber} AS TEXT) ILIKE ${'%' + searchTerm + '%'}`
+        sql`${advocates.phoneNumber} ILIKE ${'%' + searchTerm + '%'}`
       );
     }
 

--- a/src/app/api/seed/route.ts
+++ b/src/app/api/seed/route.ts
@@ -3,7 +3,13 @@ import { advocates } from "../../../db/schema";
 import { advocateData } from "../../../db/seed/advocates";
 
 export async function POST() {
-  const records = await db.insert(advocates).values(advocateData).returning();
+  // Create a new array with converted phone numbers
+  const convertedData = advocateData.map(advocate => ({
+    ...advocate,
+    phoneNumber: String(advocate.phoneNumber) // Convert number to string
+  }));
+
+  const records = await db.insert(advocates).values(convertedData).returning();
 
   return Response.json({ advocates: records });
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import Pagination, { PaginationMeta } from "./components/pagination";
 import SearchBar from "./components/searchBar";
 import Loading from "./components/loading";
 import ErrorState from "./components/error";
+import { formatPhoneNumber } from "./utils";
 
 interface Advocate {
   id: number;
@@ -13,7 +14,7 @@ interface Advocate {
   city: string;
   degree: string;
   specialties: string[];
-  yearsOfExperience: string;
+  yearsOfExperience: number;
   phoneNumber: string;
 }
 
@@ -56,7 +57,10 @@ export default function Home() {
       
       const jsonResponse = await response.json();
       
-      setAdvocates(jsonResponse.data);
+      setAdvocates(jsonResponse.data.map((advocate: Advocate) => ({
+        ...advocate,
+        phoneNumber: String(advocate.phoneNumber) // Ensure it's always a string
+      })))
       setPaginationMeta(jsonResponse.meta);
     } catch (error) {
       console.error("Error fetching advocates:", error);
@@ -207,7 +211,7 @@ export default function Home() {
                             </span>
                           </td>
                           <td className="px-4 py-3 text-primary">
-                            {advocate.phoneNumber}
+                            {formatPhoneNumber(advocate.phoneNumber)}
                           </td>
                         </tr>
                       ))}

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -1,0 +1,26 @@
+/**
+ * Formats a phone number string into a readable format
+ * 
+ * Examples:
+ * - 1234567890 becomes (123) 456-7890
+ * - 123-456-7890 becomes (123) 456-7890
+ * - (123)456-7890 becomes (123) 456-7890
+ * 
+ * @param phoneNumber The phone number to format
+ * @returns Formatted phone number
+ */
+export function formatPhoneNumber(phoneNumber?: string): string {
+    if (!phoneNumber) return ""
+    // Remove all non-numeric characters
+    const cleaned = phoneNumber.replace(/\D/g, '');
+    
+    // Check if the input is valid
+    const match = cleaned.match(/^(\d{3})(\d{3})(\d{4})$/);
+    
+    if (match) {
+      return `(${match[1]}) ${match[2]}-${match[3]}`;
+    }
+    
+    // If the phone number is not 10 digits, return the original number
+    return phoneNumber;
+  }

--- a/src/db/migrate.js
+++ b/src/db/migrate.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const { drizzle } = require("drizzle-orm/postgres-js");
 const { migrate } = require("drizzle-orm/postgres-js/migrator");
 const postgres = require("postgres");
@@ -25,3 +26,4 @@ runMigration()
 
     process.exit(1);
   });
+ 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -17,7 +17,7 @@ const advocates = pgTable("advocates", {
   degree: text("degree").notNull(),
   specialties: jsonb("payload").default([]).notNull(),
   yearsOfExperience: integer("years_of_experience").notNull(),
-  phoneNumber: bigint("phone_number", { mode: "number" }).notNull(),
+  phoneNumber: text("phone_number").notNull(),
   createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`),
 });
 


### PR DESCRIPTION
This PR is branched off [PR 5](https://github.com/jmmander/solace/pull/5)

This PR changes the advocates' phone number field from bigint to text with corresponding frontend and API updates for better handling and display of phone numbers.

Changes

- Updated database schema: phone_number column type → text
- Added migration scripts for safe data conversion
- Updated API search queries for text comparison
- Added frontend phone formatting utility
- Added dotenv package (16.5.0)
- Updated drizzle scripts to support custom migrations

Motivation
Storing phone numbers as text:
- Preserves leading zeros
- Supports international formats and extensions
- Enables flexible formatting options
- Better matches real-world usage as identifiers

<img width="196" alt="Screenshot 2025-04-12 at 8 27 45 PM" src="https://github.com/user-attachments/assets/59c6be23-27eb-46cd-a568-81f51ff76119" />

