### PR TITLE
6 - Rename payload to specialties and upgrade drizzle

### DIFF
--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -2,7 +2,7 @@
 
 Thanks for checking out my code!
 
-This project is split across 5 different PRs, each branching off the previous one. I structured it this way to make the code easily testable and review-friendly. For running the application, I recommend using the `phone-to-text-migration` branch as it contains all the changes and updates.
+This project is split across 6 different PRs, each branching off the previous one. I structured it this way to make the code easily testable and review-friendly. For running the application, I recommend using the `ensure-payloads-is-jsonb` branch as it contains all the changes and updates.
 
 ## Future Improvements
 
@@ -15,6 +15,7 @@ This project is split across 5 different PRs, each branching off the previous on
 - Add error boundires to ensure app doesn't crash
 - Make the table responsive and mobile-friendly
 - Enhance data fetching with ReactQuery or SSR
+- Optimize api calls
 - Refactor the table into its own component
 - Add comprehensive frontend tests
 - Ensure it meets accessibilty standards

--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -2,7 +2,7 @@
 
 Thanks for checking out my code!
 
-This project is split across 6 different PRs, each branching off the previous one. I structured it this way to make the code easily testable and review-friendly. For running the application, I recommend using the `ensure-payloads-is-jsonb` branch as it contains all the changes and updates. I also recommend setting up your local the database as this was the experience I optimized for.
+This project is split across 6 different PRs, each branching off the previous one. I structured it this way to make the code easily testable and review-friendly. For running the application, I recommend using the `ensure-payloads-is-jsonb` branch as it contains all the changes and updates. I also recommend running the app with your docker database as this was the experience I optimized for.
 
 ## Future Improvements
 

--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -2,7 +2,7 @@
 
 Thanks for checking out my code!
 
-This project is split across 6 different PRs, each branching off the previous one. I structured it this way to make the code easily testable and review-friendly. For running the application, I recommend using the `ensure-payloads-is-jsonb` branch as it contains all the changes and updates.
+This project is split across 6 different PRs, each branching off the previous one. I structured it this way to make the code easily testable and review-friendly. For running the application, I recommend using the `ensure-payloads-is-jsonb` branch as it contains all the changes and updates. I also recommend setting up your local the database as this was the experience I optimized for.
 
 ## Future Improvements
 

--- a/drizzle/0002_fixed_carlie_cooper.sql
+++ b/drizzle/0002_fixed_carlie_cooper.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "advocates" RENAME COLUMN "payload" TO "specialties";

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,82 @@
+{
+  "id": "6d1aa0d1-1256-49c8-ac9b-1ecd1ec8de4d",
+  "prevId": "8ab224e5-b7e3-445d-a5b7-0987c5e06ff3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.advocates": {
+      "name": "advocates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "degree": {
+          "name": "degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "specialties": {
+          "name": "specialties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "years_of_experience": {
+          "name": "years_of_experience",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1744501932155,
       "tag": "0001_change_phone_to_text",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1744665355384,
+      "tag": "0002_fixed_carlie_cooper",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "dotenv": "^16.5.0",
-        "drizzle-orm": "^0.32.1",
+        "drizzle-orm": "^0.33.0",
         "next": "^14.2.19",
         "postgres": "^3.4.4",
         "prettier": "^3.5.3",
@@ -2125,9 +2125,10 @@
       }
     },
     "node_modules/drizzle-orm": {
-      "version": "0.32.2",
-      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.32.2.tgz",
-      "integrity": "sha512-3fXKzPzrgZIcnWCSLiERKN5Opf9Iagrag75snfFlKeKSYB1nlgPBshzW3Zn6dQymkyiib+xc4nIz0t8U+Xdpuw==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.33.0.tgz",
+      "integrity": "sha512-SHy72R2Rdkz0LEq0PSG/IdvnT3nGiWuRk+2tXZQ90GVq/XQhpCzu/EFT3V2rox+w8MlkBQxifF8pCStNYnERfA==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
         "@cloudflare/workers-types": ">=3",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,11 @@
     "format": "npx prettier --write",
     "generate": "drizzle-kit generate",
     "generate:custom": "drizzle-kit generate --custom",
-    "migrate:up": "node ./src/db/migrate.js",
-    "seed": "node --loader esbuild-register/loader -r esbuild-register ./src/db/seed/index.ts"
+    "migrate:up": "node ./src/db/migrate.js"
   },
   "dependencies": {
     "dotenv": "^16.5.0",
-    "drizzle-orm": "^0.32.1",
+    "drizzle-orm": "^0.33.0",
     "next": "^14.2.19",
     "postgres": "^3.4.4",
     "prettier": "^3.5.3",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -15,7 +15,7 @@ const advocates = pgTable("advocates", {
   lastName: text("last_name").notNull(),
   city: text("city").notNull(),
   degree: text("degree").notNull(),
-  specialties: jsonb("payload").default([]).notNull(),
+  specialties: jsonb("specialties").default([]).notNull(),
   yearsOfExperience: integer("years_of_experience").notNull(),
   phoneNumber: text("phone_number").notNull(),
   createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`),


### PR DESCRIPTION
This PR is branched off: [PR 6](https://github.com/jmmander/solace/pull/6/files#diff-c7d2c320d1f7fc0aad36b8bf616a7289ca4dcf00e6e057ba8a1d354fb25b74c0)

This updates the schema to use the name specialties instead of payload. This was mainly updated for consistency.

It also upgrades the drizzle version in order to properly support jsonb in the specialties column ([see github issue for more context](https://github.com/drizzle-team/drizzle-orm/issues/724)). Previously this was a string and would throw an error when trying to each the jsonb array given the incorrect type in the DB.

I also removed the seed script from package.json because it doesn't work.